### PR TITLE
feat : 로그인 refreshToken 추가, 카카오 로그인 기능 구현, 로그아웃, 회원탈퇴 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,5 @@ out/
 src/main/resources/application-mail.yml
 src/main/resources/application-s3.yml
 src/main/resources/application.yml
+src/main/resources/application-oauth.yml
 src/main/resources/application-mail.yml

--- a/build.gradle
+++ b/build.gradle
@@ -26,12 +26,17 @@ ext {
 }
 
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+    implementation 'com.google.code.gson:gson:2.9.0'
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.3'
     implementation 'org.springframework.boot:spring-boot-starter-webflux:3.1.2'
+    implementation 'org.glassfish.web:jakarta.servlet.jsp.jstl'
     implementation 'com.googlecode.json-simple:json-simple:1.1.1'
     implementation 'org.springframework.boot:spring-boot-starter-mail:3.1.2'
     compileOnly 'org.projectlombok:lombok'
@@ -48,20 +53,19 @@ dependencies {
 */
 
     implementation group: 'io.jsonwebtoken', name: 'jjwt', version: '0.9.1'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     // com.sun.xml.bind
     implementation 'com.sun.xml.bind:jaxb-impl:4.0.1'
     implementation 'com.sun.xml.bind:jaxb-core:4.0.1'
     // javax.xml.bind
     implementation 'javax.xml.bind:jaxb-api:2.4.0-b180830.0359'
     compileOnly 'org.projectlombok:lombok'
-
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.awaitility:awaitility:3.0.0'
     testImplementation 'junit:junit:4.13.1'
-
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 }
 

--- a/src/main/java/com/example/demo/config/RedisConfig.java
+++ b/src/main/java/com/example/demo/config/RedisConfig.java
@@ -1,0 +1,36 @@
+package com.example.demo.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    private final String redisHost;
+    private final int redisPort;
+
+    public RedisConfig(@Value("${spring.data.redis.host}") final String redisHost,
+                       @Value("${spring.data.redis.port}") final int redisPort) {
+        this.redisHost = redisHost;
+        this.redisPort = redisPort;
+    }
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisHost, redisPort);
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate() {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/example/demo/config/WebConfig.java
+++ b/src/main/java/com/example/demo/config/WebConfig.java
@@ -6,7 +6,7 @@ import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
-@EnableWebMvc
+//@EnableWebMvc
 public class WebConfig implements WebMvcConfigurer {
 
     @Override

--- a/src/main/java/com/example/demo/entity/Auth.java
+++ b/src/main/java/com/example/demo/entity/Auth.java
@@ -1,12 +1,11 @@
 package com.example.demo.entity;
 
 import com.example.demo.type.AgeGroup;
-import com.example.demo.type.Authority;
 import com.example.demo.type.GenderType;
 import com.example.demo.type.Ntrp;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 
-import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.util.List;
 
@@ -50,4 +49,46 @@ public class Auth {
                     .build();
         }
     }
+
+    @Data
+    public static class Reissue {
+        @NotBlank(message = "accessToken을 입력해주세요.")
+        private String accessToken;
+
+        @NotBlank(message = "refreshToken을 입력해주세요.")
+        private String refreshToken;
+    }
+
+    @Data
+    public static class SignOut {
+        @NotBlank(message = "잘못된 요청입니다.")
+        private String accessToken;
+
+        @NotBlank(message = "잘못된 요청입니다.")
+        private String refreshToken;
+    }
+
+    @Data
+    public static class Quit {
+        @NotBlank(message = "잘못된 요청입니다.")
+        private String accessToken;
+
+        @NotBlank(message = "잘못된 요청입니다.")
+        private String refreshToken;
+
+        @NotBlank(message = "잘못된 요청입니다.")
+        private String email;
+
+        @NotBlank(message = "잘못된 요청입니다.")
+        private String password;
+    }
+
+    @Data
+    public static class SignKakao {
+        @NotBlank(message = "잘못된 요청입니다.")
+        private String code;
+        @NotBlank(message = "잘못된 요청입니다.")
+        private String provider;
+    }
+
 }

--- a/src/main/java/com/example/demo/exception/impl/NeedLoginException.java
+++ b/src/main/java/com/example/demo/exception/impl/NeedLoginException.java
@@ -1,0 +1,16 @@
+package com.example.demo.exception.impl;
+
+import com.example.demo.exception.AbstractException;
+import org.springframework.http.HttpStatus;
+
+public class NeedLoginException extends AbstractException {
+    @Override
+    public int getStatusCode() {
+        return HttpStatus.UNAUTHORIZED.value();
+    }
+
+    @Override
+    public String getMessage() {
+        return "Login Please";
+    }
+}

--- a/src/main/java/com/example/demo/exception/impl/TokenExpiredException.java
+++ b/src/main/java/com/example/demo/exception/impl/TokenExpiredException.java
@@ -1,0 +1,16 @@
+package com.example.demo.exception.impl;
+
+import com.example.demo.exception.AbstractException;
+import org.springframework.http.HttpStatus;
+
+public class TokenExpiredException extends AbstractException {
+    @Override
+    public int getStatusCode() {
+        return HttpStatus.UNAUTHORIZED.value();
+    }
+
+    @Override
+    public String getMessage() {
+        return "Token Expired";
+    }
+}

--- a/src/main/java/com/example/demo/oauth2/OAuthRequestFactory.java
+++ b/src/main/java/com/example/demo/oauth2/OAuthRequestFactory.java
@@ -1,0 +1,54 @@
+package com.example.demo.oauth2;
+
+import com.example.demo.oauth2.dto.OAuthRequest;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+
+@Component
+@RequiredArgsConstructor
+public class OAuthRequestFactory {
+    private final KakaoInfo kakaoInfo;
+
+    public OAuthRequest getRequest(String code, String provider) {
+        LinkedMultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+        if (!provider.equals("kakao")) {
+            return null;
+        }
+        map.add("grant_type", "authorization_code");
+        map.add("client_id", kakaoInfo.getKakaoClientId());
+        map.add("redirect_uri", kakaoInfo.getKakaoRedirect());
+        map.add("client_secret", kakaoInfo.getKakacoClientSecret());
+        map.add("code", code);
+
+        return new OAuthRequest(kakaoInfo.getKakaoTokenUrl(), map);
+    }
+
+    public String getProfileUrl(String provider) {
+        if (!provider.equals("kakao")) {
+            return null;
+        }
+        return kakaoInfo.getKakaoProfileUrl();
+    }
+
+    @Getter
+    @Component
+    static class KakaoInfo {
+        @Value("${spring.security.oauth2.client.registration.kakao.client_id}")
+        String kakaoClientId;
+
+        @Value("${spring.security.oauth2.client.registration.kakao.redirect_uri}")
+        String kakaoRedirect;
+
+        @Value("${spring.security.oauth2.client.registration.kakao.client_secret}")
+        String kakacoClientSecret;
+
+        @Value("${spring.security.oauth2.client.provider.kakao.token-uri}")
+        private String kakaoTokenUrl;
+
+        @Value("${spring.security.oauth2.client.provider.kakao.user-info-uri}")
+        private String kakaoProfileUrl;
+    }
+}

--- a/src/main/java/com/example/demo/oauth2/dto/AccessToken.java
+++ b/src/main/java/com/example/demo/oauth2/dto/AccessToken.java
@@ -1,0 +1,16 @@
+package com.example.demo.oauth2.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class AccessToken {
+    private String access_token;
+    private String token_type;
+    private String refresh_token;
+    private long expires_in;
+    private long refresh_token_expires_in;
+}

--- a/src/main/java/com/example/demo/oauth2/dto/OAuthRequest.java
+++ b/src/main/java/com/example/demo/oauth2/dto/OAuthRequest.java
@@ -1,0 +1,13 @@
+package com.example.demo.oauth2.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.util.LinkedMultiValueMap;
+
+@Getter
+@AllArgsConstructor
+public class OAuthRequest {
+    private String url;
+    private LinkedMultiValueMap<String, String> map;
+}

--- a/src/main/java/com/example/demo/oauth2/dto/ProfileDto.java
+++ b/src/main/java/com/example/demo/oauth2/dto/ProfileDto.java
@@ -1,0 +1,14 @@
+package com.example.demo.oauth2.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ProfileDto {
+    private String nickname;
+    private String profileImage;
+}
+

--- a/src/main/java/com/example/demo/oauth2/service/ProviderService.java
+++ b/src/main/java/com/example/demo/oauth2/service/ProviderService.java
@@ -1,0 +1,79 @@
+package com.example.demo.oauth2.service;
+
+import com.example.demo.oauth2.dto.AccessToken;
+import com.example.demo.oauth2.dto.OAuthRequest;
+import com.example.demo.oauth2.OAuthRequestFactory;
+import com.example.demo.oauth2.dto.ProfileDto;
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import javax.naming.CommunicationException;
+
+@Service
+@RequiredArgsConstructor
+public class ProviderService {
+
+    private final OAuthRequestFactory oAuthRequestFactory;
+    public AccessToken getAccessToken(String code, String provider) throws CommunicationException {
+        HttpHeaders httpHeaders = new HttpHeaders();
+        RestTemplate restTemplate = new RestTemplate();
+        httpHeaders.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        Gson gson = new Gson();
+
+        OAuthRequest oAuthRequest = oAuthRequestFactory.getRequest(code, provider);
+        HttpEntity<LinkedMultiValueMap<String, String>> request = new HttpEntity<>(oAuthRequest.getMap() , httpHeaders);
+
+        ResponseEntity<String> response = restTemplate.postForEntity(oAuthRequest.getUrl(), request, String.class);
+        try {
+            if (response.getStatusCode() == HttpStatus.OK) {
+                return gson.fromJson(response.getBody(), AccessToken.class);
+            }
+        } catch (Exception e) {
+            throw new CommunicationException();
+        }
+        throw new CommunicationException();
+    }
+
+    public ProfileDto getProfile(String accessToken, String provider) throws CommunicationException {
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        httpHeaders.set("Authorization", "Bearer " + accessToken);
+
+        String profileUrl = oAuthRequestFactory.getProfileUrl(provider);
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(null, httpHeaders);
+        ResponseEntity<String> response = restTemplate.postForEntity(profileUrl, request, String.class);
+
+        try {
+            if (response.getStatusCode() == HttpStatus.OK) {
+                return extractProfile(response, provider);
+            }
+        } catch (Exception e) {
+            throw new CommunicationException();
+        }
+        throw new CommunicationException();
+    }
+
+    private ProfileDto extractProfile(ResponseEntity<String> response, String provider) {
+        if (!provider.equals("kakao")) {
+            return null;
+        }
+        JsonParser parser = new JsonParser();
+        JsonElement element = parser.parse(response.getBody());
+        JsonObject properties = element.getAsJsonObject().get("properties").getAsJsonObject();
+        String nickname = properties.getAsJsonObject().get("nickname").getAsString();
+        String profileImage = properties.getAsJsonObject().get("profile_image").getAsString();
+        ProfileDto profileDto = new ProfileDto();
+        profileDto.setNickname(nickname);
+        profileDto.setProfileImage(profileImage);
+        return profileDto;
+    }
+}

--- a/src/main/java/com/example/demo/siteuser/controller/AuthController.java
+++ b/src/main/java/com/example/demo/siteuser/controller/AuthController.java
@@ -2,18 +2,40 @@ package com.example.demo.siteuser.controller;
 
 import com.example.demo.common.ResponseDto;
 import com.example.demo.common.ResponseUtil;
+import com.example.demo.aws.S3Uploader;
 import com.example.demo.entity.Auth;
 import com.example.demo.entity.SiteUser;
+import com.example.demo.oauth2.dto.AccessToken;
+import com.example.demo.oauth2.dto.ProfileDto;
+import com.example.demo.oauth2.service.ProviderService;
+import com.example.demo.siteuser.dto.SiteUserLoginResponseDto;
+import com.example.demo.siteuser.repository.SiteUserRepository;
 import com.example.demo.siteuser.dto.EmailRequestDto;
 import com.example.demo.siteuser.dto.NicknameRequestDto;
 import com.example.demo.siteuser.security.TokenProvider;
 //import com.example.demo.siteuser.service.EmailService;
 import com.example.demo.siteuser.service.MemberService;
+import com.example.demo.type.Authority;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.catalina.connector.Response;
+import org.springframework.data.redis.core.ReactiveSetOperations;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.naming.CommunicationException;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @RestController
@@ -21,8 +43,12 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class AuthController {
 
+    private final SiteUserRepository siteUserRepository;
+    private final RedisTemplate<String, String> redisTemplate;
     private final MemberService memberService;
     private final TokenProvider tokenProvider;
+    private final S3Uploader s3Uploader;
+    private final ProviderService providerService;
     // private final EmailService emailService; // 이메일
 
     @PostMapping("/signup")
@@ -33,7 +59,7 @@ public class AuthController {
             // SiteUser siteUser = memberService.register(request);
             // emailService.sendEmail(siteUser.getId(), siteUser.getEmail());
 
-            return ResponseEntity.ok(ResponseUtil.SUCCESS("회원 가입 성공! 메일 인증 후 로그인하세요."));
+            return ResponseEntity.ok(ResponseUtil.SUCCESS("회원 가입 성공"));
         } catch (Exception e) {
             e.printStackTrace();
             return new ResponseEntity<>(ResponseUtil.SUCCESS("회원 가입 실패"), HttpStatus.INTERNAL_SERVER_ERROR);
@@ -46,8 +72,97 @@ public class AuthController {
         var member = this.memberService.authenticate(request);
         //List<String> role = new ArrayList<>();
         //role.add(member.getRoles().toString());
-        var token = this.tokenProvider.generateToken(member.getEmail(), member.getRoles());
+        var token = this.tokenProvider.generateAccessToken(member.getEmail(), member.getRoles());
+        var refreshToken = this.tokenProvider.generateRefreshToken(member.getEmail());
+        var id = member.getId();
+        SiteUserLoginResponseDto siteUserLoginResponseDto = new SiteUserLoginResponseDto();
+        siteUserLoginResponseDto.setId(id);
+        siteUserLoginResponseDto.setAccessToken(token);
+        siteUserLoginResponseDto.setRefreshToken(refreshToken);
+        return ResponseEntity.ok(siteUserLoginResponseDto);
+    }
+
+    @PostMapping("/signin/kakao")
+    public ResponseEntity<?> signinKakao(@RequestBody Auth.SignKakao request) {
+        // 카카오용 API
+
+        try {
+            AccessToken accessToken = providerService.getAccessToken(request.getCode(), request.getProvider());
+            //List<String> role = new ArrayList<>();
+            //role.add(member.getRoles().toString());
+            ProfileDto profile = providerService.getProfile(accessToken.getAccess_token(), request.getProvider());
+            var member = siteUserRepository.findByNickname(profile.getNickname());
+            if (member.isPresent()) {
+                var refreshToken = this.tokenProvider.generateRefreshToken(member.get().getEmail());
+                var acsToken = this.tokenProvider.generateAccessToken(member.get().getEmail(), member.get().getRoles());
+                SiteUserLoginResponseDto siteUserLoginResponseDto = new SiteUserLoginResponseDto();
+                siteUserLoginResponseDto.setId(member.get().getId());
+                siteUserLoginResponseDto.setEmail(member.get().getEmail());
+                siteUserLoginResponseDto.setAccessToken(acsToken);
+                siteUserLoginResponseDto.setRefreshToken(refreshToken);
+                return ResponseEntity.ok(siteUserLoginResponseDto);
+            } else {
+                SiteUserLoginResponseDto siteUserLoginResponseDto = new SiteUserLoginResponseDto();
+                siteUserLoginResponseDto.setNickname(profile.getNickname());
+                siteUserLoginResponseDto.setProfileImage(profile.getProfileImage());
+                siteUserLoginResponseDto.setRedirectUrl("redirect:/register");
+                return ResponseEntity.ok(siteUserLoginResponseDto);
+            }
+        } catch (CommunicationException e) {
+            return new ResponseEntity<>("Wrong Request", HttpStatus.BAD_REQUEST);
+        }
+
+    }
+
+    @PostMapping("/reissue")
+    public ResponseEntity<?> reissue(@RequestBody Auth.Reissue reissue) {
+        Authentication authentication = tokenProvider.getAuthentication(reissue.getAccessToken());
+        String refreshToken = redisTemplate.opsForValue().get(authentication.getName());
+        if (refreshToken == null || ObjectUtils.isEmpty(refreshToken)) {
+            return new ResponseEntity<>("Wrong Request", HttpStatus.BAD_REQUEST);
+        }
+        if (!refreshToken.equals(reissue.getRefreshToken())) {
+            return new ResponseEntity<>("Refresh Token Information Does Not Match.", HttpStatus.BAD_REQUEST);
+        }
+        var member = siteUserRepository.findByEmail(authentication.getName());
+        var token = tokenProvider.generateAccessToken(authentication.getName(), member.get().getRoles());
+        //var rftoken = tokenProvider.generateRefreshToken(authentication.getName());
+        //String[] tokenList = {token, rftoken};
+        //return new ResponseEntity<>("The token information has been updated.", HttpStatus.OK);
         return ResponseEntity.ok(token);
+    }
+
+    @PostMapping("/signout")
+    public ResponseEntity<?> signout(@RequestBody Auth.SignOut signOut) {
+        var accessToken = signOut.getAccessToken();
+        if (!StringUtils.hasText(accessToken) || !this.tokenProvider.validateToken(accessToken)) {
+            return new ResponseEntity<>("Wrong Request", HttpStatus.BAD_REQUEST);
+        }
+        Authentication authentication = tokenProvider.getAuthentication(accessToken);
+        if (redisTemplate.opsForValue().get(authentication.getName()) != null) {
+            redisTemplate.delete(authentication.getName());
+        }
+        Long expiration = tokenProvider.getExpiration(accessToken);
+        redisTemplate.opsForValue().set(accessToken, "logout", expiration, TimeUnit.MILLISECONDS);
+
+        return new ResponseEntity<>("LogOut Completed", HttpStatus.OK);
+    }
+
+    @DeleteMapping("/quit")
+    public ResponseEntity<?> quit(@RequestBody Auth.Quit request) {
+        var accessToken = request.getAccessToken();
+        if (!StringUtils.hasText(accessToken) || !this.tokenProvider.validateToken(accessToken)) {
+            return new ResponseEntity<>("Wrong Request", HttpStatus.BAD_REQUEST);
+        }
+        Authentication authentication = tokenProvider.getAuthentication(accessToken);
+        if (redisTemplate.opsForValue().get(authentication.getName()) != null) {
+            redisTemplate.delete(authentication.getName());
+        }
+        Long expiration = tokenProvider.getExpiration(accessToken);
+        redisTemplate.opsForValue().set(accessToken, "quit", expiration, TimeUnit.MILLISECONDS);
+
+        var result = this.memberService.withdraw(request);
+        return new ResponseEntity<>("Quit Completed", HttpStatus.OK);
     }
 
     @PostMapping(path = "/check-email")
@@ -69,4 +184,5 @@ public class AuthController {
     public void viewConfirmEmail(@RequestParam String token) {
         emailService.verifyEmail(token);
     }*/
+
 }

--- a/src/main/java/com/example/demo/siteuser/dto/SiteUserLoginResponseDto.java
+++ b/src/main/java/com/example/demo/siteuser/dto/SiteUserLoginResponseDto.java
@@ -1,0 +1,19 @@
+package com.example.demo.siteuser.dto;
+
+import com.example.demo.entity.SiteUser;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SiteUserLoginResponseDto {
+    private Long id;
+    private String email;
+    private String nickname;
+    private String profileImage;
+    private String accessToken;
+    private String refreshToken;
+    private String redirectUrl;
+}

--- a/src/main/java/com/example/demo/siteuser/repository/SiteUserRepository.java
+++ b/src/main/java/com/example/demo/siteuser/repository/SiteUserRepository.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 public interface SiteUserRepository extends JpaRepository<SiteUser, Long> {
 
     Optional<SiteUser> findByEmail(String email);
+    Optional<SiteUser> findByNickname(String nickname);
     boolean existsByEmail(String email);
     boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/example/demo/siteuser/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/demo/siteuser/security/JwtAuthenticationFilter.java
@@ -1,17 +1,28 @@
 package com.example.demo.siteuser.security;
 
+import com.example.demo.exception.impl.NeedLoginException;
+import com.example.demo.exception.impl.TokenExpiredException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.Builder;
+import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.NestedServletException;
+
 import java.io.IOException;
 
 @Slf4j
@@ -21,20 +32,54 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     public static final String TOKEN_HEADER = "Authorization";
     public static final String TOKEN_PREFIX = "Bearer ";
-
+    private final RedisTemplate<String, String> redisTemplate;
     private final TokenProvider tokenProvider;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
-        String token = this.resolveTokenFromRequest(request);
 
-        if (StringUtils.hasText(token) && this.tokenProvider.validateToken(token)) {
-            //토큰 유효성 검증
-            Authentication auth = this.tokenProvider.getAuthentication(token);
-            SecurityContextHolder.getContext().setAuthentication(auth);
+        try {
+            String token = this.resolveTokenFromRequest(request);
+            if (StringUtils.hasText(token) && this.tokenProvider.validateToken(token)) {
+                //토큰 유효성 검증
+                String isLogout = (String)redisTemplate.opsForValue().get(token);
+                if (ObjectUtils.isEmpty(isLogout)) {
+                    Authentication auth = this.tokenProvider.getAuthentication(token);
+                    SecurityContextHolder.getContext().setAuthentication(auth);
+                } else {
+                    throw new NeedLoginException();
+                }
+            }
+            filterChain.doFilter(request, response);
+        } catch (NeedLoginException e) {
+            ErrorResponse errorResponse = ErrorResponse.builder()
+                            .code(e.getStatusCode())
+                                    .message(e.getMessage()).build();
+            response.setStatus(HttpStatus.UNAUTHORIZED.value());
+            ObjectMapper objectMapper = new ObjectMapper();
+            objectMapper.registerModule(new JavaTimeModule());
+            response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+            response.getWriter().flush();
+        } catch (TokenExpiredException e) {
+            ErrorResponse errorResponse = ErrorResponse.builder()
+                            .code(e.getStatusCode())
+                                    .message(e.getMessage()).build();
+            response.setStatus(HttpStatus.UNAUTHORIZED.value());
+            ObjectMapper objectMapper = new ObjectMapper();
+            objectMapper.registerModule(new JavaTimeModule());
+            response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+            response.getWriter().flush();
         }
-        filterChain.doFilter(request, response);
+
+    }
+
+
+    @Data
+    @Builder
+    public static class ErrorResponse {
+        private final int code;
+        private final String message;
     }
 
     private String resolveTokenFromRequest(HttpServletRequest request) {

--- a/src/main/java/com/example/demo/siteuser/security/JwtExceptionFilter.java
+++ b/src/main/java/com/example/demo/siteuser/security/JwtExceptionFilter.java
@@ -1,0 +1,53 @@
+package com.example.demo.siteuser.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.NoSuchElementException;
+
+@Slf4j
+@Component
+public class JwtExceptionFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (JwtException | IllegalArgumentException ex) {
+            log.error("유효하지 않은 토큰입니다.");
+            setErrorResponse(HttpStatus.UNAUTHORIZED, response, ex);
+        } catch (NoSuchElementException ex) {
+            log.error("사용자를 찾을 수 없습니다.");
+            setErrorResponse(HttpStatus.UNAUTHORIZED, response, ex);
+        } catch (ArrayIndexOutOfBoundsException ex) {
+            log.error("토큰을 추출할 수 없습니다.");
+            setErrorResponse(HttpStatus.UNAUTHORIZED, response, ex);
+        } catch (NullPointerException ex) {
+            filterChain.doFilter(request, response);
+        }
+
+    }
+    private void setErrorResponse(HttpStatus status, HttpServletResponse response, Throwable ex) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        response.setStatus(status.value());
+        response.setContentType("application/json; charset=UTF-8");
+        JwtAuthenticationFilter.ErrorResponse errorResponse = new JwtAuthenticationFilter.ErrorResponse(HttpStatus.UNAUTHORIZED.value(), ex.getMessage());
+        try {
+            response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/com/example/demo/siteuser/security/RefreshToken.java
+++ b/src/main/java/com/example/demo/siteuser/security/RefreshToken.java
@@ -1,0 +1,26 @@
+package com.example.demo.siteuser.security;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+public class RefreshToken {
+
+    @Id
+    private String email;
+
+    private String refreshToken;
+
+
+    public RefreshToken(final String email, final String refreshToken) {
+        this.email = email;
+        this.refreshToken = refreshToken;
+    }
+
+    public String getRefreshToken() {
+        return refreshToken;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+}

--- a/src/main/java/com/example/demo/siteuser/security/SecurityConfiguration.java
+++ b/src/main/java/com/example/demo/siteuser/security/SecurityConfiguration.java
@@ -10,7 +10,6 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
-import org.springframework.security.config.annotation.web.configurers.HttpBasicConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -25,20 +24,22 @@ public class SecurityConfiguration {
 
     private final CustomAuthFailureHandler customFailurHandler;
     private final JwtAuthenticationFilter authenticationFilter;
+    private final JwtExceptionFilter jwtExceptionFilter;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .cors(Customizer.withDefaults())
-                .httpBasic(HttpBasicConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement((session) -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authz -> authz
-                        .requestMatchers("/api/auth/**", "/api/auth/signin","/api/auth/upload-profile-image", "/api/auth/kakao/signup", "/api/auth/kakao/callback", "/api/matches/list", "/api/matches/**", "/api/users/**", "/api/aws/**").permitAll()
+                        .requestMatchers("/api/auth/signup", "/api/auth/signin/**", "/api/auth/reissue","/api/auth/signout", "/api/auth/quit", "/api/auth/upload-profile-image", "/api/matches/list", "/api/matches/**", "/api/users/**", "/api/aws/**").permitAll()
                         .anyRequest().authenticated())
                 .addFilterBefore(this.authenticationFilter, UsernamePasswordAuthenticationFilter.class)
-                .formLogin(loginFail -> loginFail.disable());
+                .addFilterBefore(this.jwtExceptionFilter, JwtAuthenticationFilter.class)
+                .formLogin(AbstractHttpConfigurer::disable);
                 //.defaultSuccessUrl("/api/matches/list"));
 
         return http.build();

--- a/src/main/java/com/example/demo/siteuser/service/MemberService.java
+++ b/src/main/java/com/example/demo/siteuser/service/MemberService.java
@@ -39,6 +39,17 @@ public class MemberService implements UserDetailsService {
         return result;
     }
 
+    public SiteUser withdraw(Auth.Quit member) {
+        var user = this.siteUserRepository.findByEmail(member.getEmail())
+                .orElseThrow(() -> new AuthEmailNotFoundException());
+
+        if (!this.passwordEncoder.matches(member.getPassword(), user.getPassword())) {
+            throw new AuthWrongPasswordException();
+        }
+        this.siteUserRepository.delete(user);
+        return user;
+    }
+
     public SiteUser authenticate(Auth.SignIn member) {
 
         var user = this.siteUserRepository.findByEmail(member.getEmail())

--- a/src/main/java/com/example/demo/type/Authority.java
+++ b/src/main/java/com/example/demo/type/Authority.java
@@ -3,5 +3,6 @@ package com.example.demo.type;
 public enum Authority {
 
     ROLE_USER,
-    ROLE_ADMIN
+    ROLE_ADMIN,
+    ROLE_GUEST
 }


### PR DESCRIPTION
### 변경사항
**AS-IS**
로그인 accessToken만 사용.

**TO-BE**
로그인 refreshToken 추가.
카카오 로그인 기능 구현.
로그아웃, 회원탈퇴 기능 구현.

### 테스트
- [ ] 테스트 코드
- [x] API 테스트 